### PR TITLE
Fix aligned_storage template argument order

### DIFF
--- a/include/ditto/polymorphic_object.h
+++ b/include/ditto/polymorphic_object.h
@@ -77,7 +77,7 @@ class PolymorphicObject {
  private:
   constexpr static size_t ALIGNMENT = std::max({alignof(DerivedClasses)...});
   constexpr static size_t BUFFER_SIZE = std::max({sizeof(DerivedClasses)...});
-  typename std::aligned_storage<ALIGNMENT, BUFFER_SIZE>::type m_memory_buffer;
+  typename std::aligned_storage<BUFFER_SIZE, ALIGNMENT>::type m_memory_buffer;
   Base* m_ptr = nullptr;
 
   static_assert((std::is_base_of_v<Base, DerivedClasses> && ...),

--- a/include/ditto/result.h
+++ b/include/ditto/result.h
@@ -72,7 +72,7 @@ class Result {
   constexpr static std::size_t ALIGNMENT = std::max(alignof(Ok), alignof(Err));
   constexpr static std::size_t BUFFER_SIZE = std::max(sizeof(Ok), sizeof(Err));
   bool m_is_ok = false;
-  typename std::aligned_storage<ALIGNMENT, BUFFER_SIZE>::type m_memory_buffer;
+  typename std::aligned_storage<BUFFER_SIZE, ALIGNMENT>::type m_memory_buffer;
 
   Result() = default;
 };
@@ -119,7 +119,7 @@ class Result<Ok, void> {
   constexpr static std::size_t ALIGNMENT = alignof(Ok);
   constexpr static std::size_t BUFFER_SIZE = sizeof(Ok);
   bool m_is_ok = false;
-  typename std::aligned_storage<ALIGNMENT, BUFFER_SIZE>::type m_memory_buffer;
+  typename std::aligned_storage<BUFFER_SIZE, ALIGNMENT>::type m_memory_buffer;
 
   Result() = default;
 };
@@ -170,7 +170,7 @@ class Result<void, Err> {
   constexpr static std::size_t ALIGNMENT = alignof(Err);
   constexpr static std::size_t BUFFER_SIZE = sizeof(Err);
   bool m_is_ok = false;
-  typename std::aligned_storage<ALIGNMENT, BUFFER_SIZE>::type m_memory_buffer;
+  typename std::aligned_storage<BUFFER_SIZE, ALIGNMENT>::type m_memory_buffer;
 
   Result() = default;
 };


### PR DESCRIPTION
We were using incorrect ordering for alignment and length.