### PR TITLE
Add nodiscard for Result class

### DIFF
--- a/include/ditto/result.h
+++ b/include/ditto/result.h
@@ -212,6 +212,18 @@ class [[nodiscard]] Result<void, Err> {
   Result() = default;
 };
 
+#define DITTO_VERIFY_OK(expression)          \
+  {                                          \
+    auto _evaluated_result = expression;     \
+    DITTO_VERIFY(_evaluated_result.is_ok()); \
+  }
+
+#define DITTO_VERIFY_ERR(expression)            \
+  {                                             \
+    auto _evaluated_result = expression;        \
+    DITTO_VERIFY(_evaluated_result.is_error()); \
+  }
+
 #define DITTO_PROPAGATE(expression)            \
   ({                                           \
     auto _result = expression;                 \

--- a/test/result.cpp
+++ b/test/result.cpp
@@ -81,6 +81,34 @@ TEST(ResultTest, void_ok_enum_err) {
   Ditto::g_assert = nullptr;
 }
 
+TEST(ResultTest, verify_ok) {
+  StrictMock<Ditto::MockAssert> assert;
+  Ditto::g_assert = &assert;
+
+  auto returns_result = []() -> Result<void, uint32_t> {
+    return Result<void, uint32_t>::ok();
+  };
+  DITTO_VERIFY_OK(returns_result());
+
+  EXPECT_CALL(assert, assert_failed(_, _, _));
+  DITTO_VERIFY_ERR(returns_result());
+
+  Ditto::g_assert = nullptr;
+}
+
+TEST(ResultTest, verify_err) {
+  StrictMock<Ditto::MockAssert> assert;
+  Ditto::g_assert = &assert;
+
+  auto returns_result = []() -> Result<void, uint32_t> { return 123; };
+  DITTO_VERIFY_ERR(returns_result());
+
+  EXPECT_CALL(assert, assert_failed(_, _, _));
+  DITTO_VERIFY_OK(returns_result());
+
+  Ditto::g_assert = nullptr;
+}
+
 TEST(ResultTest, propagate_error) {
   auto divide_and_add = [](uint32_t numerator, uint32_t denominator,
                            uint32_t add) -> Result<double, const char*> {


### PR DESCRIPTION
By adding the [[nodiscard]] attribute to the Result class we force all
uses of a result to be used and check it's value, reducing cases where
we might drop a Result without realizing it.