### PR TITLE
Add ResourceLock<T, M>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(
   test/result.cpp
   test/badge.cpp
   test/fixed.cpp
+  test/resource_lock.cpp
 )
 
 target_include_directories(DittoTests PRIVATE test)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Generic reusable C++ software components for both embedded and general purpose s
   * `Ditto::Badge`: Implements the Badge pattern. Functions taking a Badge object can only be called from the templated class of the Badge, since a badge can only be constructed from this templated class.
   * `Ditto::Result`: Encapsulation of the return type of a function. Could either be and Ok value or an Error and has method to find out which one it is and obtain the value.
   * `Ditto::FixedPoint`: Implements a fixed point integer with support for common operations.
+  * `Ditto::ResourceLock`: Implements a wrapper of an object and a mutex. The underlying object can only be accessed when the mutex has been locked, ensuring that the access to the resource is always mutually exclusive. It treats all accesses as potentially changing the state of the object, therefore one must also lock for reads even if no other thread is mutating the state of the underlying object.
   * It features a custom assert implementation that can be overriden by the user.
 
 

--- a/include/ditto/resource_lock.h
+++ b/include/ditto/resource_lock.h
@@ -1,0 +1,36 @@
+
+#pragma once
+
+#include <mutex>
+#include <utility>
+
+namespace Ditto {
+
+template <class T, class M>
+class ResourceLock {
+ public:
+  template <class... Args>
+  constexpr explicit ResourceLock(Args... args)
+      : m_resource(std::forward<Args>(args)...) {}
+
+  template <class Action,
+            std::enable_if_t<std::is_invocable_v<Action, T&>, bool> = false>
+  inline void lock(Action action) {
+    std::scoped_lock<M> lock{m_mutex};
+    action(m_resource);
+  }
+
+  // TODO(javier-varez): Handle copy and move constructors and assignment
+  // operators to also lock the object when reading from it. For now these two
+  // operations are disallowed
+  ResourceLock(const ResourceLock&) = delete;
+  ResourceLock(ResourceLock&&) = delete;
+  auto operator=(const ResourceLock&) -> ResourceLock& = delete;
+  auto operator=(ResourceLock &&) -> ResourceLock& = delete;
+
+ private:
+  M m_mutex;
+  T m_resource;
+};
+
+}  // namespace Ditto

--- a/test/resource_lock.cpp
+++ b/test/resource_lock.cpp
@@ -1,0 +1,27 @@
+
+#include "ditto/resource_lock.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+TEST(ResourceLockTest, can_default_construct) {
+  Ditto::ResourceLock<int, std::mutex> resource;
+}
+
+TEST(ResourceLockTest, can_construct_resource_forwarding_args) {
+  Ditto::ResourceLock<int, std::mutex> int_resource{123};
+  Ditto::ResourceLock<std::string, std::mutex> str_resource{"my_string"};
+}
+
+TEST(ResourceLockTest, can_lock_resource) {
+  Ditto::ResourceLock<int, std::mutex> int_resource{123};
+
+  int_resource.lock([](auto& res) {
+    EXPECT_EQ(res, 123);
+    res = 3;
+  });
+
+  int_resource.lock([](auto& res) { EXPECT_EQ(res, 3); });
+}


### PR DESCRIPTION
The ResourceLock encapsulates an object of type `T` and a mutex object
of type `M`. The underlying object can only be accessed by calling
`lock` and providing a closure that will get invoked when the resource
has been successfully locked.