### PR TITLE
Add ReadWriteLock<T, M>

### DIFF
--- a/include/ditto/resource_lock.h
+++ b/include/ditto/resource_lock.h
@@ -33,4 +33,56 @@ class ResourceLock {
   T m_resource;
 };
 
+template <class T, class M>
+class ReadWriteLock {
+ public:
+  template <class... Args>
+  constexpr explicit ReadWriteLock(Args... args)
+      : m_resource(std::forward<Args>(args)...) {}
+
+  template <class Action,
+            std::enable_if_t<std::is_invocable_v<Action, T&>, bool> = false>
+  inline void write_lock(Action action) {
+    std::scoped_lock<M> lock{m_global_mutex};
+    action(m_resource);
+  }
+
+  template <
+      class Action,
+      std::enable_if_t<std::is_invocable_v<Action, const T&>, bool> = false>
+  inline void read_lock(Action action) {
+    {
+      std::scoped_lock<M> r_lock{m_read_mutex};
+      m_num_readers++;
+      if (m_num_readers == 1) {
+        m_global_mutex.lock();
+      }
+    }
+
+    action(static_cast<const T>(m_resource));
+
+    {
+      std::scoped_lock<M> r_lock{m_read_mutex};
+      m_num_readers--;
+      if (m_num_readers == 0) {
+        m_global_mutex.unlock();
+      }
+    }
+  }
+
+  // TODO(javier-varez): Handle copy and move constructors and assignment
+  // operators to also lock the object when reading from it. For now these two
+  // operations are disallowed
+  ReadWriteLock(const ReadWriteLock&) = delete;
+  ReadWriteLock(ReadWriteLock&&) = delete;
+  auto operator=(const ReadWriteLock&) -> ReadWriteLock& = delete;
+  auto operator=(ReadWriteLock &&) -> ReadWriteLock& = delete;
+
+ private:
+  std::uint32_t m_num_readers = 0;
+  M m_read_mutex;
+  M m_global_mutex;
+  T m_resource;
+};
+
 }  // namespace Ditto


### PR DESCRIPTION
The ReadWriteLock differs from a ReasourceLock in that it can be locked
multiple times by multiple readers from differents (or the same) threads
because they do not mutate the state of the resource at any point in
time, making it safe to use it concurrently for reading from multiple
threads.

On the other hand, write locks are exclusive and cannot be held while
any other thread (or the same thread) holds another read or write lock.