### PR TITLE
Add constructors from smart ptrs to NonNullPtr

### DIFF
--- a/include/ditto/non_null_ptr.h
+++ b/include/ditto/non_null_ptr.h
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "ditto/assert.h"
 
 namespace Ditto {
@@ -12,6 +14,14 @@ template <class T>
 class NonNullPtr final {
  public:
   NonNullPtr(T* _Nonnull ptr) : m_ptr(ptr) { DITTO_VERIFY(m_ptr != nullptr); }
+
+  NonNullPtr(const std::unique_ptr<T>& ptr) : m_ptr(ptr.get()) {
+    DITTO_VERIFY(m_ptr != nullptr);
+  }
+
+  NonNullPtr(const std::shared_ptr<T>& ptr) : m_ptr(ptr.get()) {
+    DITTO_VERIFY(m_ptr != nullptr);
+  }
 
   NonNullPtr(const NonNullPtr&) = default;
   NonNullPtr(NonNullPtr&&) = default;

--- a/test/non_null_ptr.cpp
+++ b/test/non_null_ptr.cpp
@@ -15,6 +15,34 @@ TEST(NonNullPtrTest, Nullptr) {
   StrictMock<Ditto::MockAssert> assert;
   Ditto::g_assert = &assert;
   EXPECT_CALL(assert, assert_failed(_, _, _));
-  Ditto::NonNullPtr<int> ptr{nullptr};
+  int* null_int = nullptr;
+  Ditto::NonNullPtr<int> ptr{null_int};
   Ditto::g_assert = nullptr;
+}
+
+TEST(NonNullPtrTest, FromRawPointer) {
+  int val = 0;
+  auto mutate = [](Ditto::NonNullPtr<int> int_ptr) { *int_ptr = 7; };
+
+  mutate(&val);
+
+  EXPECT_EQ(val, 7);
+}
+
+TEST(NonNullPtrTest, FromUniquePtr) {
+  std::unique_ptr<int> val_ptr = std::make_unique<int>(0);
+  auto mutate = [](Ditto::NonNullPtr<int> int_ptr) { *int_ptr = 7; };
+
+  mutate(val_ptr);
+
+  EXPECT_EQ(*val_ptr, 7);
+}
+
+TEST(NonNullPtrTest, FromSharedPointer) {
+  std::shared_ptr<int> val_ptr = std::make_shared<int>(0);
+  auto mutate = [](Ditto::NonNullPtr<int> int_ptr) { *int_ptr = 7; };
+
+  mutate(val_ptr);
+
+  EXPECT_EQ(*val_ptr, 7);
 }


### PR DESCRIPTION
For convenience and type-erasure when passing pointers to a function.
NonNullPtr does not own the memory it references.