### PR TITLE
Fix unused result warning with DITTO_VERIFY

### DIFF
--- a/include/ditto/assert.h
+++ b/include/ditto/assert.h
@@ -21,7 +21,7 @@ void unimplemented(const char* function, int line, const char* file);
 
 #else
 
-#define DITTO_VERIFY(x) (x)
+#define DITTO_VERIFY(x) ((void)(x))
 #define DITTO_UNIMPLEMENTED()
 
 #endif


### PR DESCRIPTION
This happens when NDEBUG is defined.