### PR TITLE
Remove implicit construction of Ditto::Result

### DIFF
--- a/include/ditto/fixed_flat_map.h
+++ b/include/ditto/fixed_flat_map.h
@@ -47,14 +47,14 @@ requires Hashable<H, K> class FixedFlatMap {
     const auto slot = find_slot(hash, key);
     auto& meta = m_metadata[slot];
     if (meta.isUsed()) {
-      return Error::KeyAlreadyUsed;
+      return Ditto::Result<V*, Error>::error(Error::KeyAlreadyUsed);
     }
 
     auto new_element =
         new (&m_storage[slot]) KvPair{key, std::forward<T>(args)...};
     meta.setUsed(hash);
 
-    return &new_element->right();
+    return Ditto::Result<V*, Error>::ok(&new_element->right());
   }
 
   Ditto::Result<V*, Error> operator[](const K& key) {
@@ -62,11 +62,11 @@ requires Hashable<H, K> class FixedFlatMap {
     const auto slot = find_slot(hash, key);
     auto& meta = m_metadata[slot];
     if (!meta.isUsed()) {
-      return Error::KeyNotFound;
+      return Ditto::Result<V*, Error>::error(Error::KeyNotFound);
     }
 
     auto kv_pair = reinterpret_cast<KvPair*>(&m_storage[slot]);
-    return &kv_pair->right();
+    return Ditto::Result<V*, Error>::ok(&kv_pair->right());
   }
 
   Ditto::Result<void, Error> remove(const K& key) {
@@ -74,7 +74,7 @@ requires Hashable<H, K> class FixedFlatMap {
     const auto slot = find_slot(hash, key);
     auto& meta = m_metadata[slot];
     if (!meta.isUsed()) {
-      return Error::KeyNotFound;
+      return Ditto::Result<void, Error>::error(Error::KeyNotFound);
     }
 
     meta.setDeleted();

--- a/include/ditto/fixed_vector.h
+++ b/include/ditto/fixed_vector.h
@@ -169,25 +169,25 @@ class FixedVector {
   template <class... U>
   auto emplace(U... args) noexcept -> Result<T*, Error> {
     if (m_length == CAPACITY) {
-      return Error::VectorIsFull;
+      return Result<T*, Error>::error(Error::VectorIsFull);
     }
 
     auto* val = new (&m_storage[m_length++]) T{std::forward<U>(args)...};
-    return val;
+    return Result<T*, Error>::ok(val);
   }
 
   auto push(T value) noexcept -> Result<T*, Error> {
     if (m_length == CAPACITY) {
-      return Error::VectorIsFull;
+      return Result<T*, Error>::error(Error::VectorIsFull);
     }
 
     auto* val = new (&m_storage[m_length++]) T{std::move(value)};
-    return val;
+    return Result<T*, Error>::ok(val);
   }
 
   auto pop() noexcept -> Ditto::Result<T, Error> {
     if (m_length == 0) {
-      return Error::VectorIsEmpty;
+      return Result<T*, Error>::error(Error::VectorIsEmpty);
     }
 
     const auto idx = m_length;
@@ -197,25 +197,26 @@ class FixedVector {
     const T ret_item = std::move(inner_item);
 
     inner_item->~T();
-    return ret_item;
+    return Result<T, Error>::oK(ret_item);
   }
 
   [[nodiscard]] auto size() const noexcept -> std::size_t { return m_length; }
 
   auto operator[](std::size_t index) noexcept -> Result<T*, Error> {
     if (index >= m_length) {
-      return Error::IndexOutOfRange;
+      return Result<T*, Error>::error(Error::IndexOutOfRange);
     }
 
-    return reinterpret_cast<T*>(&m_storage[index]);
+    return Result<T*, Error>::ok(reinterpret_cast<T*>(&m_storage[index]));
   }
 
   auto operator[](std::size_t index) const noexcept -> Result<const T*, Error> {
     if (index >= m_length) {
-      return Error::IndexOutOfRange;
+      return Result<const T*, Error>::error(Error::IndexOutOfRange);
     }
 
-    return reinterpret_cast<const T*>(&m_storage[index]);
+    return Result<const T*, Error>::ok(
+        reinterpret_cast<const T*>(&m_storage[index]));
   }
 
   auto cbegin() -> Iterator<const T> { return Iterator<const T>{this, 0}; }


### PR DESCRIPTION
This also removes the limitation of the Ok and Err types having to be
different, since now the propagation is explicit in that it propagates
an error type.